### PR TITLE
Add CyclOSM tile layer

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,7 @@ var whateverLayer = new WhateverTileLayer([
   ['https://{s}.tiles.mapbox.com/v4/mapbox.comic/{z}/{x}/{y}.png?access_token={mbkey}', 'Comic', 'Mapbox', 'https://www.mapbox.com/about/maps/'],
   ['https://{s}.tiles.mapbox.com/v4/mapbox.pencil/{z}/{x}/{y}.png?access_token={mbkey}', 'Pencil', 'Mapbox', 'https://www.mapbox.com/about/maps/'],
   ['https://{s}.tiles.mapbox.com/v4/mapbox.pirates/{z}/{x}/{y}.png?access_token={mbkey}', 'Pirates', 'Mapbox', 'https://www.mapbox.com/about/maps/'],
+  ['https://{s}.tile-cyclosm.openstreetmap.fr/cyclosm/{z}/{x}/{y}.png', 'CyclOSM', 'CyclOSM', 'https://www.cyclosm.org/'],
   ], {
     attribution: 'Map &copy; <a href=\"http://openstreetmap.org\">OpenStreetMap</a> | Click on the map for tile authors',
     // Please do not steal my API keys!


### PR DESCRIPTION
Hi,

CyclOSM (https://github.com/cyclosm/cyclosm-cartocss-style/) is a new FOSS map style targeted for cyclists. What about including it in openwhatevermap layers?

Thanks!
Best,